### PR TITLE
move BUILD_DIR variable into Kconfig

### DIFF
--- a/config/global/paths.in
+++ b/config/global/paths.in
@@ -55,6 +55,10 @@ config BUILD_TOP_DIR
     string
     default "${CT_WORK_DIR:-${CT_TOP_DIR}/.build}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
 
+config BUILD_DIR
+    string
+    default "${CT_BUILD_TOP_DIR}/build"
+
 config PREFIX_DIR
     string
     prompt "Prefix directory"

--- a/scripts/crosstool-NG.sh
+++ b/scripts/crosstool-NG.sh
@@ -114,7 +114,6 @@ fi
 
 # Where will we work?
 CT_WORK_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}"
-CT_BUILD_DIR="${CT_BUILD_TOP_DIR}/build"
 CT_DoExecLog ALL mkdir -p "${CT_WORK_DIR}"
 CT_DoExecLog DEBUG rm -f "${CT_WORK_DIR}/backtrace"
 


### PR DESCRIPTION
this allows users to reference this variable,
for ex. in TARGET_CFLAGS to remap paths.

Signed-off-by: Norbert Lange <nolange79@gmail.com>